### PR TITLE
add an option to update apt cache on package install tasks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,12 @@ mariadb_overwrite_global_mycnf: True
 # @en
 mariadb_transaction_isolation_level: READ-COMMITTED
 
+# @var mariadb_apt_cache_update:description: >
+# Automatically update apt cache on package installations.
+# This setting will only applied on apt-based operating systems e.g. Ubuntu.
+# @end
+mariadb_apt_cache_update: False
+
 # @var mariadb_packages:description: >
 # Define a custom list of packages to install. Default value depends on your operating system.
 # @end
@@ -49,7 +55,7 @@ mariadb_skip_name_resolve: False
 # @var mariadb_datadir:example: $ "/var/lib/mysql"
 
 # @var mariadb_sql_mode:description: >
-# MariaDB supports several different modes. You can pass a list of options 
+# MariaDB supports several different modes. You can pass a list of options
 # to to suit your needs.
 # @end
 mariadb_sql_mode: []

--- a/molecule/ubuntu1804/playbook.yml
+++ b/molecule/ubuntu1804/playbook.yml
@@ -1,5 +1,8 @@
 ---
 - name: Converge
   hosts: all
+  vars:
+    mariadb_apt_cache_update: True
+
   roles:
     - role: mariadb

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -2,12 +2,14 @@
 - name: Ensure dependencies are installed
   package:
     name: "{{ item }}"
+    update_cache: "{{ mariadb_apt_cache_update }}"
     state: present
   loop: "{{ mariadb_packages_extra + __mariadb_requirements }}"
 
 - name: Ensure MariaDB packages are installed
   package:
     name: "{{ item }}"
+    update_cache: "{{ mariadb_apt_cache_update }}"
     state: present
   register: __mariadb_install
   loop: "{{ mariadb_packages }}"


### PR DESCRIPTION
Will fix failed package installation in some situations on apt-based systems