### PR TITLE
feat: add option mariadb_environment_isolation for RH 7 based systems

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,21 @@
 mariadb_root_password: root
 mariadb_enabled_on_startup: True
 
+# @var mariadb_environment_isolation:description: >
+# On RedHat/CentOS 7 based systems Software Collections are used to install a more up to date version of MariaDB. By default
+# Software Collection packages will be installed completely isolated from the default system package environment to
+# avoid conflicts. In order to use the Software Collections packages, users need to do "few things" differently than
+# with normal RPMs. For example, they need to use 'scl enable' call, which changes environment variables like `PATH`
+# or `LD_LIBRARY_PATH`, so that binaries under alternative path are found. Users also need to use different names for
+# systemd services. Or, some scripts might use full paths for the binaries, like /usr/bin/mysql.
+#
+# If only one MariaDB version is installed on this system the isolation can be disabled. `mariadb_environment_isolation`
+# allow users to choose, whether they prefer isolation or usage simplicity.
+#
+# On systems not based on RedHat/CentOS 7 this option has no effect and will be ignored.
+# @end
+# mariadb_environment_isolation: $ True
+
 # @var mariadb_overwrite_global_mycnf:description: >
 # Whether my.cnf should be updated on every run.
 # @end

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,14 +7,14 @@ mariadb_root_password: root
 mariadb_enabled_on_startup: True
 
 # @var mariadb_environment_isolation:description: >
-# On RedHat/CentOS 7 based systems Software Collections are used to install a more up to date version of MariaDB. By default
-# Software Collection packages will be installed completely isolated from the default system package environment to
-# avoid conflicts. In order to use the Software Collections packages, users need to do "few things" differently than
-# with normal RPMs. For example, they need to use 'scl enable' call, which changes environment variables like `PATH`
-# or `LD_LIBRARY_PATH`, so that binaries under alternative path are found. Users also need to use different names for
-# systemd services. Or, some scripts might use full paths for the binaries, like /usr/bin/mysql.
+# On RedHat/CentOS 7 based systems, Software Collections are used to install a more up-to-date version of MariaDB. By default,
+# Software Collection packages will be installed completely isolated from the default system package environment to avoid
+# conflicts. In order to use the Software Collections packages, users need to do "few things" differently than with normal
+# RPMs. For example, they need to use 'scl enable' call, which changes environment variables like `PATH` or `LD_LIBRARY_PATH`,
+# so that binaries under alternative path are found. Users also need to use different names for systemd services. Or, some
+# scripts might use full paths for the binaries, like /usr/bin/mysql.
 #
-# If only one MariaDB version is installed on this system the isolation can be disabled. `mariadb_environment_isolation`
+# If only one MariaDB version is installed on this system, the isolation can be disabled. `mariadb_environment_isolation`
 # allow users to choose, whether they prefer isolation or usage simplicity.
 #
 # On systems not based on RedHat/CentOS 7 this option has no effect and will be ignored.

--- a/molecule/centos7/converge.yml
+++ b/molecule/centos7/converge.yml
@@ -2,6 +2,7 @@
 - name: Converge
   hosts: all
   vars:
+    mariadb_environment_isolation: False
     mariadb_packages_extra:
       - centos-release-scl
 

--- a/molecule/centos7/tests/test_default.py
+++ b/molecule/centos7/tests/test_default.py
@@ -8,17 +8,26 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_mariadb_running_and_enabled(host):
-    mariadb = host.service("rh-mariadb101-mariadb")
+    mariadb = host.service("rh-mariadb103-mariadb")
     assert mariadb.is_running
     assert mariadb.is_enabled
 
 
-def test_mariadb_config(host):
-    config = host.run("/opt/rh/rh-mariadb101/root/bin/mysqladmin variables | tr -d ' '").stdout
+def test_mariadb_syspaths(host):
+    mysql_client = host.file("/usr/bin/mysql")
+    mysql_version = host.run("/usr/bin/mysql --version").stdout
 
-    assert "|datadir|/var/opt/rh/rh-mariadb101/lib/mysql/|" in config
+    assert mysql_client.exists
+    assert "/opt/rh/rh-mariadb103/root/usr/bin/mysql" in mysql_version
+    assert "Distrib 10.3" in mysql_version
+
+
+def test_mariadb_config(host):
+    config = host.run("/opt/rh/rh-mariadb103/root/bin/mysqladmin variables | tr -d ' '").stdout
+
+    assert "|datadir|/var/opt/rh/rh-mariadb103/lib/mysql/|" in config
     assert "|port|3306|" in config
     assert "|socket|/var/lib/mysql/mysql.sock|" in config
-    assert "|pid_file|/var/run/rh-mariadb101-mariadb/mariadb.pid|" in config
+    assert "|pid_file|/var/run/rh-mariadb103-mariadb/mariadb.pid|" in config
     assert "|tx_isolation|READ-COMMITTED|" in config
-    assert "|log_error|/var/opt/rh/rh-mariadb101/log/mariadb/mariadb.log|" in config
+    assert "|log_error|/var/opt/rh/rh-mariadb103/log/mariadb/mariadb.log|" in config

--- a/vars/redhat-7.yml
+++ b/vars/redhat-7.yml
@@ -1,18 +1,22 @@
 ---
-__mariadb_daemon: rh-mariadb101-mariadb
-__mariadb_mysql_binary: /opt/rh/rh-mariadb101/root/bin/mysql
+__mariadb_daemon: rh-mariadb103-mariadb
+__mariadb_mysql_binary: /opt/rh/rh-mariadb103/root/bin/mysql
 
-__mariadb_packages:
-  - rh-mariadb101-mariadb
-  - rh-mariadb101-mariadb-server
+__mariadb_packages_base:
+  - rh-mariadb103-mariadb
+  - rh-mariadb103-mariadb-server
+__mariadb_packages_syspaths:
+  - rh-mariadb103-syspaths
+
+__mariadb_packages: "{{ __mariadb_packages_base if mariadb_environment_isolation | default(True) | bool else __mariadb_packages_base + __mariadb_packages_syspaths }}"
 
 __mariadb_requirements:
   - MySQL-python
 
-__mariadb_datadir: /var/opt/rh/rh-mariadb101/lib/mysql/
+__mariadb_datadir: /var/opt/rh/rh-mariadb103/lib/mysql/
 __mariadb_log_file_group: mysql
-__mariadb_log_error: /var/opt/rh/rh-mariadb101/log/mariadb/mariadb.log
-__mariadb_pid_file: /var/run/rh-mariadb101-mariadb/mariadb.pid
-__mariadb_config_file: /etc/opt/rh/rh-mariadb101/my.cnf
-__mariadb_config_include_dir: /etc/opt/rh/rh-mariadb101/my.cnf.d
+__mariadb_log_error: /var/opt/rh/rh-mariadb103/log/mariadb/mariadb.log
+__mariadb_pid_file: /var/run/rh-mariadb103-mariadb/mariadb.pid
+__mariadb_config_file: /etc/opt/rh/rh-mariadb103/my.cnf
+__mariadb_config_include_dir: /etc/opt/rh/rh-mariadb103/my.cnf.d
 __mariadb_socket: /var/lib/mysql/mysql.sock


### PR DESCRIPTION
Fixes: https://github.com/owncloud-ansible/mariadb/issues/6

Description:
On RedHat/CentOS 7 based systems, Software Collections are used to install a more up-to-date version of MariaDB. By default, Software Collection packages will be installed completely isolated from the default system package environment to avoid conflicts. In order to use the Software Collections packages, users need to do "few things" differently than with normal RPMs. For example, they need to use 'scl enable' call, which changes environment variables like `PATH` or `LD_LIBRARY_PATH`, so that binaries under alternative path are found. Users also need to use different names for systemd services. Or, some scripts might use full paths for the binaries, like /usr/bin/mysql.

If only one MariaDB version is installed on this system, the isolation can be disabled. `mariadb_environment_isolation` allow users to choose, whether they prefer isolation or usage simplicity.

BREAKING CHANGE: For RedHat 7 based distributions, MariaDB packages `rh-mariadb101*` were updated to `rh-mariadb103*`. Depending on your data directory configuration, you may need to migrate it manually after the upgrade.